### PR TITLE
Added before_widget and after_widget arguments

### DIFF
--- a/widget.php
+++ b/widget.php
@@ -34,7 +34,8 @@ class kiyoh_review extends WP_Widget
             $image_dir = plugins_url("/", __FILE__)
             ?>
 
-            <div class="kiyoh-shop-snippets">
+            <?php echo $args['before_widget']; ?>
+	    <div class="kiyoh-shop-snippets">
                 <div class="rating-box">
                     <div class="rating" style="width:<?php echo $rating_percentage; ?>%"></div>
                 </div>
@@ -73,6 +74,7 @@ class kiyoh_review extends WP_Widget
                     padding: 0;
                 }
             </style>
+	    <?php echo $args['after_widget']; ?>
         <?php endif;
     }
 


### PR DESCRIPTION
WordPress themes using the [register_sidebar](https://developer.wordpress.org/reference/functions/register_sidebar/) method output your widget without the correct wrapper. This is caused by not calling the before_widget and after_widget arguments at the right time. Please check out this PR fixing this.