### PR TITLE
🐛 fix: post_type was called incorrectly. Order properties should not be accessed directly. 

### DIFF
--- a/kiyoh-customerreview.php
+++ b/kiyoh-customerreview.php
@@ -39,7 +39,7 @@ function check_kiyoh_review($post_id, $post)
 {
     $kiyoh_options = kiyoh_getOption();
 
-    if (!($post instanceof WC_Order) && $post->post_type != 'shop_order') {
+    if (!($post instanceof WC_Order)) {
         return;
     }
     

--- a/kiyoh-customerreview.php
+++ b/kiyoh-customerreview.php
@@ -38,9 +38,11 @@ function check_kiyoh_review_on_order_save($post, $wc_data_store)
 function check_kiyoh_review($post_id, $post)
 {
     $kiyoh_options = kiyoh_getOption();
-    if ($post->post_type != 'shop_order' && !($post instanceof WC_Order)) {
+
+    if (!($post instanceof WC_Order) && $post->post_type != 'shop_order') {
         return;
     }
+    
     $order = new WC_Order($post_id);
     $wpmlLanguage = $order->get_meta('wpml_language');
     if ($wpmlLanguage){


### PR DESCRIPTION
This PR fixes the PHP message:

`post_type was called incorrectly. Order properties should not be accessed directly.`

It is not allowed to call `->post_type` directly on the `WC_Order` object. Switching this check around prevents this from happening.